### PR TITLE
Add a Note About Helix buffer_name Expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ o = ":sh forgelink %{file_path_absolute}:%{cursor_line} --copy"
 
 `space o` copies a link to the current line. `%{file_path_absolute}` is used so
 it works regardless of the directory Helix was launched from.
+If you are using a version released before
+[helix-editor/helix#12989](https://github.com/helix-editor/helix/pull/12989)
+was merged, you should use `%{buffer_name}` instead.
 
 ### Kakoune
 


### PR DESCRIPTION
For anyone using the last release ([25.07.1](https://github.com/helix-editor/helix/releases/tag/25.07.1)) `file_path_absolute` is not available. In order to limit confusion we should add a note about using `buffer_name` instead.

This change can be removed (or reverted) after the next Helix release, since `file_path_absolute` will be included.